### PR TITLE
introduce tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: python
 python:
     - "2.7"
+    - "3.4"
     - "3.5"
 addons:
   apt:
     packages:
     - freetds-dev
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py34,py35
 skip_missing_interpreters=true
+
+[tox:travis]
+2.7 = py27
+3.4 = py34
+3.5 = py35
 
 [testenv]
 deps=-rtox-requirements.txt
@@ -17,6 +22,10 @@ norecursedirs=.tox .git venv
 commands=
     py.test -v mssqlcli
 
+[testenv:py34]
+commands=
+    py.test -v mssqlcli
+
 [testenv:py35]
 commands=
     py.test -v mssqlcli
@@ -30,4 +39,3 @@ commands=
 basepython=python3.5
 commands=
     py.test --cov=. --cov-report term mssqlcli
-


### PR DESCRIPTION
Use Tox-Travis instead of standard Tox. Allows Travis to test multiple python versions concurrently, rather than Tox testing them serially.

partial for Issue #4 .