### PR TITLE
Closes #8: Add --fail-under for Tox to allow homogenous testing.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,26 +21,17 @@ norecursedirs=.tox .git venv
 [testenv:py27]
 commands=
     coverage run -m pytest -v --strict mssqlcli
+    coverage report -m --fail-under 100
 
 [testenv:py34]
 commands=
     coverage run -m pytest -v --strict mssqlcli
+    coverage report -m --fail-under 100
 
 [testenv:py35]
 commands=
     coverage run -m pytest -v --strict mssqlcli
-
-[testenv:py27verbose]
-basepython=python
-commands=
-    coverage run -m pytest -v --strict mssqlcli
-    coverage report -m
-
-[testenv:py35verbose]
-basepython=python3.5
-commands=
-    coverage run -m pytest -v --strict mssqlcli
-    coverage report -m
+    coverage report -m --fail-under 100 
 
 [testenv:pep8]
 basepython = python2


### PR DESCRIPTION
Fixes #8.

Adding --fail-under to Tox allows local testing to match the testing ran by Travis-CI.
